### PR TITLE
Update configurator.py

### DIFF
--- a/config_handler/configurator.py
+++ b/config_handler/configurator.py
@@ -71,7 +71,8 @@ def get_collectd_process():
     API endpoint for get collectd status
     :return:
     """
-    return {COLLECTD_SERVICE: get_collectd_status(), VERSION: get_collectd_version()}
+    #return {COLLECTD_SERVICE: get_collectd_status(), VERSION: get_collectd_version()}
+    return {COLLECTD_SERVICE: get_collectd_status()}
 
 
 def enabled_fluentd(data):
@@ -96,7 +97,8 @@ def get_fluentd_process():
     API endpoint for get fluentd status
     :return:
     """
-    return {FLUENTD_SERVICE: get_fluentd_status(), VERSION: get_fluentd_version()}
+    #return {FLUENTD_SERVICE: get_fluentd_status(), VERSION: get_fluentd_version()}
+    return {FLUENTD_SERVICE: get_fluentd_status()}
 
 
 def set_fluentd_config(logging):


### PR DESCRIPTION
Fix for:SPP-194
The response time for "api/config" call varies mainly because of getting fluentd version . The command td-agent --version takes anywhere between 1-15s to response.

The version is not used in any place. Removed the version details from the api response.

Testcase:
Tested configurator is u and running and response of the api is less than or equal to 1 s.